### PR TITLE
Generate `ActiveModel::Serializer` attributes

### DIFF
--- a/active_model_serializers-json_schema.gemspec
+++ b/active_model_serializers-json_schema.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Sean Doyle"]
   spec.email         = ["sean.p.doyle24@gmail.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = %q{Generate ActiveModel::Serializer attributes from a JSON Schema}
+  spec.description   = %q{Generate ActiveModel::Serializer attributes from a JSON Schema}
+  spec.homepage      = "https://github.com/seanpdoyle/active_model_serializers-json_schema"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
@@ -33,4 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+
+  spec.add_dependency "active_model_serializers", ">= 0.8"
 end

--- a/lib/active_model_serializers/json_schema.rb
+++ b/lib/active_model_serializers/json_schema.rb
@@ -1,7 +1,24 @@
 require "active_model_serializers/json_schema/version"
+require "pathname"
 
 module ActiveModelSerializers
   module JsonSchema
-    # Your code goes here...
+    def self.included(other_module)
+      other_module.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def json_schema(file:)
+        file_path = Pathname.new(file)
+        json = JSON.parse(file_path.read)
+        type = json.fetch("type")
+
+        if type == "object"
+          attributes_from_schema = json.fetch("properties", {}).keys
+
+          self.attributes(attributes_from_schema)
+        end
+      end
+    end
   end
 end

--- a/spec/active_model_serializers/json_schema_spec.rb
+++ b/spec/active_model_serializers/json_schema_spec.rb
@@ -1,11 +1,58 @@
 require "spec_helper"
+require "active_model_serializers"
 
 RSpec.describe ActiveModelSerializers::JsonSchema do
   it "has a version number" do
     expect(ActiveModelSerializers::JsonSchema::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  context "when the path to the JSON Schema is configured" do
+    it "declares attributes based on a JSON Schema" do
+      schema_file = create_schema("article", <<-JS)
+        {
+          "type": "object",
+          "properties": {
+            "id": { "type": "integer" },
+            "title": { "type": "string" },
+            "body": { "type": "string" },
+            "created_at": { "type": "date" }
+          }
+        }
+      JS
+      serializer_class = Class.new(ActiveModel::Serializer) do
+        include ActiveModelSerializers::JsonSchema
+
+        json_schema file: schema_file.path
+      end
+      article_class = Class.new do
+        include ActiveModel::Model
+        include ActiveModel::Serialization
+
+        attr_accessor :body, :created_at, :id, :title
+      end
+      article = article_class.new(
+        id: 1,
+        title: "The Article",
+        body: "The body of the article",
+        created_at: DateTime.new(2017, 1, 1, 0, 0, 0),
+      )
+      serializer = serializer_class.new(article)
+
+      payload = serializer.serializable_hash
+
+      expect(payload).to eq(
+        "id" => article.id,
+        "title" => article.title,
+        "body" => article.body,
+        "created_at" => "2017-01-01",
+      )
+    end
+  end
+
+  def create_schema(name, json)
+    tempfile = Tempfile.new(name)
+    tempfile.write(json.to_s)
+    tempfile.close
+    tempfile
   end
 end


### PR DESCRIPTION
Given a JSON Schema file, generate `attribute` declarations in a
serializer.